### PR TITLE
Refactor playlist and lyrics scripts

### DIFF
--- a/applem-get-playlist.py
+++ b/applem-get-playlist.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-"""Fetch Apple Music playlist and extract song IDs using Playwright.
+"""Fetch Apple Music playlist JSON using Playwright.
 
 This script opens Apple Music in a real browser so the user can sign in.
 The authenticated cookies and localStorage are stored for future runs.
 After obtaining `developerToken` and `musicUserToken` from MusicKit it
 makes an authenticated request to the playlist endpoint and saves the
-returned song IDs to ``song_ids.txt``.  Tokens are also persisted to
+JSON response to ``playlist.json``. Tokens are also persisted to
 ``tokens.json`` for reuse.
 """
 
@@ -41,7 +41,6 @@ PLAYLIST_QUERY = {
 
 STATE_FILE = Path("state.json")
 TOKENS_FILE = Path("tokens.json")
-SONG_IDS_FILE = Path("song_ids.txt")
 use_persistent_context = False
 USER_DATA_DIR = "user-data"
 
@@ -146,15 +145,10 @@ async def main(playlist_id: str) -> None:
             FETCH_JSON_JS,
             {"url": playlist_url, "devToken": dev_token, "userToken": user_token},
         )
-        Path("playlist_response.json").write_text(
-            json.dumps(final, ensure_ascii=False, indent=2), encoding="utf-8"
+        Path("playlist.json").write_text(
+            json.dumps(final.get("data"), ensure_ascii=False, indent=2), encoding="utf-8"
         )
-        print("Playlist response saved to playlist_response.json")
-
-        songs = final.get("data", {}).get("resources", {}).get("songs", {})
-        song_ids = list(songs.keys())
-        SONG_IDS_FILE.write_text("\n".join(song_ids), encoding="utf-8")
-        print(f"Extracted {len(song_ids)} song IDs -> {SONG_IDS_FILE}")
+        print("Playlist response saved to playlist.json")
 
         if not use_persistent_context:
             await browser.close()

--- a/applem-parse-playlist.py
+++ b/applem-parse-playlist.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Parse Apple Music playlist JSON and output a CSV with song details."""
+
+import csv
+import json
+from pathlib import Path
+
+PLAYLIST_JSON = Path("playlist.json")
+OUTPUT_CSV = Path("playlist.csv")
+
+FIELDNAMES = [
+    "catalogId",
+    "songId",
+    "song name",
+    "artistName",
+    "albumName",
+    "contentRating",
+    "hasLyrics",
+]
+
+def main() -> None:
+    data = json.loads(PLAYLIST_JSON.read_text(encoding="utf-8"))
+    songs = data.get("library-songs", [])
+    rows = []
+    for item in songs:
+        attrs = item.get("attributes", {})
+        params = attrs.get("playParams", {})
+        rows.append({
+            "catalogId": params.get("catalogId", ""),
+            "songId": params.get("id", ""),
+            "song name": attrs.get("name", ""),
+            "artistName": attrs.get("artistName", ""),
+            "albumName": attrs.get("albumName", ""),
+            "contentRating": attrs.get("contentRating", ""),
+            "hasLyrics": str(bool(attrs.get("hasLyrics", False))).lower(),
+        })
+
+    with OUTPUT_CSV.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Rename and simplify playlist fetcher to save raw playlist JSON
- Add playlist parser to produce CSV of song metadata
- Update lyric fetcher to process all songs from CSV with configurable delay and write outputs into a dedicated `lyrics` folder

## Testing
- `python -m py_compile applem-get-playlist.py applem-parse-playlist.py applem-get-syllable-lyrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4e06bebb8832cb884decdf0b0dfa2